### PR TITLE
Fix "invalid subscription error"

### DIFF
--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -1305,7 +1305,7 @@ topics: List[TopicDescriptor] = [
     ),
     # Switches
     TopicDescriptor(
-        topic="N/+/switch/+/SwitchableOutput/output_{output}/State",
+        topic="N/+/switch/+/SwitchableOutput/{output}/State",
         message_type=MetricKind.SWITCH,
         short_id="switch_{output}_state",
         name="Switch {output} State",
@@ -1314,7 +1314,7 @@ topics: List[TopicDescriptor] = [
         enum=GenericOnOff,
     ),
     TopicDescriptor(
-        topic="N/+/switch/+/SwitchableOutput/output_{output}/Dimming",
+        topic="N/+/switch/+/SwitchableOutput/{output}/Dimming",
         message_type=MetricKind.NUMBER,
         short_id="switch_{output}_dimming",
         name="Switch {output} Dimming",


### PR DESCRIPTION
I pulled the latest of `main` and tried to run `victron_mqtt.utils.view_metrics` but when I clicked the connect button it failed with an "ValueError: Invalid subscription filter".

I asked Claude for help and ended up with this fix - it does allow me to run the UI successfully but I don't know how "correct" it is - it looks like the breaking code was added in 9a920a4.

Here's some snippets from Claude figuring out the problem and suggesting the fix:

> The issue is with topic 109: `N/+/switch/+/SwitchableOutput/output_+/State`. The problem is the underscore character `_` followed by a `+` wildcard: `output_+`.

> The topic definition uses a placeholder `{output}` which should be replaced with a wildcard `+` when creating the subscription.

> The issue is clear now. The _remove_placeholders function properly converts `{output}` to `+`, but the problem is that in the topic string `N/+/switch/+/SwitchableOutput/output_{output}/State`, the placeholder `{output}` is part of a larger string `output_{output}`.
> When the regex `r'\{[^}]+\}'` replaces `{output}` with `+`, it becomes `output_+,` which is an invalid MQTT topic filter. The underscore character `_` followed directly by a wildcard `+` is not allowed in MQTT topic filters.

> Let me create a fix by modifying the topic pattern: The issue is that the topic pattern `output_{output}` creates an invalid MQTT subscription when the `{output}` placeholder is replaced with `+`, resulting in `output_+` which is not a valid MQTT topic filter.
> Looking at the MQTT specification, wildcards must be used as separate topic levels. The correct approach is to change the topic pattern to use just `{output}` instead of `output_{output}`, so it becomes a proper wildcard `+` when replaced.