### PR TITLE
add test for duplicate names

### DIFF
--- a/tests/static_test.py
+++ b/tests/static_test.py
@@ -15,7 +15,7 @@ def test_topics():
     5. Correct metric nature for energy/power types
     6. Valid topic structure patterns
     7. Valid short_id format (lowercase letters, numbers, hyphens, underscores, and placeholders; cannot start/end with underscore)
-    8. No Duplicate names (except for attributes)
+    8. No Duplicate DeviceTypes + Names (except for attributes)
     """
     from victron_mqtt._victron_topics import topics
     from victron_mqtt.constants import MetricKind, ValueType, MetricType, MetricNature
@@ -32,13 +32,13 @@ def test_topics():
             else:
                 short_ids[short_id] = descriptor.topic
 
-    # Check for duplicate names
+    # Check for duplicate devices+names
     names = {}
     for descriptor in topics:
         if descriptor.message_type != MetricKind.ATTRIBUTE:
-            name = descriptor.name
+            name = f"devicetype '{descriptor.device_type}' name '{descriptor.name}'"
             if name in names:
-                errors.append(f"Duplicate name '{name}' found in topics: '{descriptor.topic}' and '{names[name]}'")
+                errors.append(f"Duplicate {name} found in topics: '{descriptor.topic}' and '{names[name]}'")
             else:
                 names[name] = descriptor.topic
 


### PR DESCRIPTION
This test fails as of now because there are right now with 4 errors:

```
E           Failed: Found 4 issues in topic_map:
E             - Duplicate name 'Dynamic ESS Target SOC' found in topics: 'N/+/system/+/DynamicEss/MinimumSoc' and 'N/+/system/+/DynamicEss/TargetSoc'
E             - Duplicate name 'Total Yield' found in topics: 'N/+/pvinverter/+/Ac/Energy/Forward' and 'N/+/solarcharger/+/Yield/User'
E             - Duplicate name 'Temperature' found in topics: 'N/+/tank/+/Temperature' and 'N/+/temperature/+/Temperature'
E             - Duplicate name 'Current {phase}' found in topics: 'N/+/multi/+/Ac/In/1/{phase}/I' and 'N/+/pvinverter/+/Ac/{phase}/Current

```

these need to get fixed prior to merging.