### PR TITLE
Limit inverter power in ESS

### DIFF
--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -1722,4 +1722,16 @@ topics: List[TopicDescriptor] = [
         value_type=ValueType.FLOAT,
         precision=None # Use full precision of GPS device
     ),
+    TopicDescriptor(
+        topic="N/+/settings/+/Settings/CGwacs/MaxDischargePower",
+        message_type=MetricKind.NUMBER,
+        short_id="system_ess_max_inverter_power_limit",
+        name="ESS max inverter power limit",
+        unit_of_measurement="W",
+        metric_type=MetricType.POWER,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.SYSTEM,
+        value_type=ValueType.INT,
+        min_max_range=RangeType.DYNAMIC,
+    ),
 ]


### PR DESCRIPTION
Defines the MQTT topic for setting the maximum inverter power in ESS mode. Disabling the limit is done by setting the value to -1.

<img width="1795" height="1201" alt="1" src="https://github.com/user-attachments/assets/1b6c49fd-748d-42b0-a86c-db687ae53db3" />
<img width="1875" height="1247" alt="2" src="https://github.com/user-attachments/assets/38812142-6f5f-4d31-ba65-85fb34ddeef6" />