### PR TITLE
fix handling "empty" VICTRON_TEST_ROOT_PREFIX

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,11 @@ def config_password():
 
 @pytest.fixture
 def config_root_prefix():
-    return os.getenv("VICTRON_TEST_ROOT_PREFIX", None)
+    prefix = os.getenv("VICTRON_TEST_ROOT_PREFIX", None)
+    if prefix and prefix not in [""]:
+        return prefix
+    else:
+        return None
 
 @pytest.fixture
 def config_use_ssl() -> bool:


### PR DESCRIPTION
This results in topcs starting with a /N...

i.e: with `export VICTRON_TEST_ROOT_PREFIX=""`
```
2025-08-24 17:26:21 - INFO -[140439122944704] - Reading installation ID
2025-08-24 17:26:21 - DEBUG -[140439122944704] - Subscribing to: /N/+/system/0/Serial
```

this waits until we reach a timeout and the test fails