### PR TITLE
fstring does not work with quotes in my python deployment

### DIFF
--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -213,7 +213,7 @@ async def test_number_message(create_mocked_hub):
     # Validate that publish was called with the correct topic and value
     assert published, "Expected publish to be called after setting value"
     assert published['topic'] == "W/123/evcharger/170/SetCurrent", f"Expected topic 'W/123/evcharger/170/SetCurrent', got {published['topic']}"
-    assert published['value'] == '{"value": 42}', f"Expected published value to be {'{"value": 42}'}, got {published['value']}"
+    assert published['value'] == '{"value": 42}', f"Expected published value to be {'{value: 42}'}, got {published['value']}"
 
     # Restore the original publish method
     hub.publish = orig_publish


### PR DESCRIPTION
results in the following error message otherwise
```
E     File "/home/msperl/victron_mqtt/tests/static_hub_test.py", line 216
E       assert published['value'] == '{"value": 42}', f"Expected published value to be {'{"value": 42}'}, got {published['value']}"
E                                                                                          ^^^^^
E   SyntaxError: f-string: unterminated string
```

Why this happens only in one installation is unclear as of now (Debian 12.11 - Python 3.11.2) But it is definitely a quoting issue - `\"` does not work either