### PR TITLE
Export all Grid Frequencies with precission of 2

### DIFF
--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -694,7 +694,7 @@ topics: List[TopicDescriptor] = [
         metric_nature=MetricNature.INSTANTANEOUS,
         device_type=DeviceType.INVERTER,
         value_type=ValueType.FLOAT,
-        precision=1,
+        precision=2,
     ),
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/ActiveIn/{phase}/S",


### PR DESCRIPTION
the global Grid freuquency is exporterd at precission=2 
while the per phase frequencies were only exportet at precession=1