### PR TITLE
Added topics for solarcharger and inverter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 """Configuration for tests, mostly Victron Venus device connection settings.
 
 Can be overridden by environment variables:
-VENUS_TEST_HOST - The host or IP address of the Venus device. Default "venus.local."
-VENUS_TEST_PORT - The port of the Venus device. Default 1883
-VENUS_TEST_USERNAME - The username for the Venus device. Default None
-VENUS_TEST_PASSWORD - The password for the Venus device. Default None
+VICTRON_MQTT_SERVER - The host or IP address of the Venus device. Default "venus.local."
+VICTRON_MQTT_PORT - The port of the Venus device. Default 1883
+VICTRON_TEST_USERNAME - The username for the Venus device. Default None
+VICTRON_TEST_PASSWORD - The password for the Venus device. Default None
 VENUS_TEST_USE_SSL - Whether to use SSL for the connection. Default False
+VICTRON_TEST_ROOT_PREFIX - The root prefix for the MQTT topics. Default None
 
 """
 

--- a/victron_mqtt/__init__.py
+++ b/victron_mqtt/__init__.py
@@ -7,7 +7,7 @@ from .device import Device
 from .hub import Hub, CannotConnectError, ProgrammingError, NotConnectedError
 from .metric import Metric
 from .switch import Switch
-from ._victron_enums import DeviceType, InverterState, InverterMode, GenericOnOff, EvChargerMode, InverterOverloadAlarmEnum, FluidType, TemperatureType, TemperatureStatus, SolarChargerState, ESSMode, MultiState, DESSReactiveStrategy, DESSStrategy, DESSErrorCode, DESSRestrictions, VictronDeviceEnum
+from ._victron_enums import DeviceType, State, InverterMode, GenericOnOff, EvChargerMode, InverterOverloadAlarmEnum, FluidType, TemperatureType, TemperatureStatus, ESSMode, MultiState, DESSReactiveStrategy, DESSStrategy, DESSErrorCode, DESSRestrictions, VictronDeviceEnum, PhoenixInverterMode, ErrorCode
 
 __all__ = [
     "Hub",
@@ -27,11 +27,10 @@ __all__ = [
     "MetricKind",
     "RangeType",
     "InverterOverloadAlarmEnum",
-    "InverterState",
+    "State",
     "TemperatureStatus",
     "TemperatureType",
     "FluidType",
-    "SolarChargerState",
     "ESSMode",
     "MultiState",
     "DESSReactiveStrategy",
@@ -39,4 +38,6 @@ __all__ = [
     "DESSErrorCode",
     "DESSRestrictions",
     "VictronDeviceEnum",
+    "PhoenixInverterMode",
+    "ErrorCode",
 ]

--- a/victron_mqtt/_victron_enums.py
+++ b/victron_mqtt/_victron_enums.py
@@ -37,8 +37,14 @@ class InverterMode(VictronEnum):
     On = (3, "On")
     Off = (4, "Off")
 
-class InverterState(VictronEnum):
-    """Inverter State Enum"""
+class PhoenixInverterMode(VictronEnum):
+    """Inverter Mode Enum"""
+    INVERTER = (2, "Inverter")
+    OFF = (4, "Off")
+    ECO = (4, "Eco")
+
+class State(VictronEnum):
+    """State Enum"""
     Off = (0, "Off")
     LowPower = (1, "Low Power")
     Fault = (2, "Fault")
@@ -52,6 +58,10 @@ class InverterState(VictronEnum):
     PowerAssist = (10, "Power Assist")
     PowerSupply = (11, "Power Supply")
     Sustain = (244, "Sustain")
+    StartingUp = (245, "Starting Up")
+    RepeatedAbsorption = (246, "Repeated Absorption")
+    AutoEqualize = (247, "Auto Equalize / Recondition")
+    BatterySafe = (248, "Battery Safe")
     ExternalControl = (252, "External Control")
 
 class InverterOverloadAlarmEnum(VictronEnum):
@@ -110,16 +120,6 @@ class ESSMode(VictronEnum):
     KeepCharged = (2, "keep charged")
     ExternalControl = (3, "External control")
 
-class SolarChargerState(VictronEnum):
-    Off = (0, "Off")
-    Fault = (2, "Fault")
-    Bulk = (3, "Bulk")
-    Absorption = (4, "Absorption")
-    Float = (5, "Float")
-    Storage = (6, "Storage")
-    Equalize = (7, "Equalize")
-    ExternalControl = (252, "External control")
-
 class DESSReactiveStrategy(VictronEnum):
     SCHEDULED_SELFCONSUME = (1, "Scheduled Self-Consume")
     SCHEDULED_CHARGE_ALLOW_GRID = (2, "Scheduled Charge Allow Grid")
@@ -168,3 +168,25 @@ class DESSRestrictions(VictronEnum):
     GRID_TO_BATTERY_RESTRICTED = (1, "Grid to battey energy flow restricted")
     BATTERY_TO_GRID_RESTRICTED = (2, "Battery to grid energy flow restricted")
     NO_FLOW = (3, "No energy flow between battery and grid")
+
+class ErrorCode(VictronEnum):
+    NO_ERROR = (0, "No error")
+    BATTERY_VOLTAGE_TOO_HIGH = (2, "Battery voltage too high")
+    CHARGER_TEMPERATURE_TOO_HIGH = (17, "Charger temperature too high")
+    CHARGER_OVER_CURRENT = (18, "Charger over current")
+    CHARGER_CURRENT_REVERSED = (19, "Charger current reversed")
+    BULK_TIME_LIMIT_EXCEEDED = (20, "Bulk time limit exceeded")
+    CURRENT_SENSOR_ISSUE = (21, "Current sensor issue")
+    TERMINALS_OVERHEATED = (26, "Terminals overheated")
+    CONVERTER_ISSUE = (28, "Converter issue")
+    INPUT_VOLTAGE_TOO_HIGH = (33, "Input voltage too high (solar panel)")
+    INPUT_CURRENT_TOO_HIGH = (34, "Input current too high (solar panel)")
+    INPUT_SHUTDOWN_BATTERY_VOLTAGE_TOO_HIGH = (38, "Input shutdown (battery voltage too high)")
+    INPUT_SHUTDOWN_REVERSE_CURRENT = (39, "Input shutdown (reverse current)")
+    LOST_COMMUNICATION_WITH_DEVICE = (65, "Lost communication with device")
+    SYNCHRONIZED_CHARGING_CONFIG_ISSUE = (66, "Synchronized charging config issue")
+    BMS_CONNECTION_LOST = (67, "BMS connection lost")
+    NETWORK_MISCONFIGURED = (68, "Network misconfigured")
+    FACTORY_CALIBRATION_DATA_LOST = (116, "Factory calibration data lost")
+    INVALID_INCOMPATIBLE_FIRMWARE = (117, "Invalid/incompatible firmware")
+    USER_SETTINGS_INVALID = (119, "User settings invalid")

--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -5,7 +5,7 @@ Maps all the MQTT topics to either attributes or metrics.
 from typing import List
 from .constants import MetricKind, MetricNature, MetricType, ValueType, RangeType
 from .data_classes import TopicDescriptor
-from ._victron_enums import DESSReactiveStrategy, DESSStrategy, DeviceType, ESSMode, FluidType, InverterMode, GenericOnOff, EvChargerMode, InverterOverloadAlarmEnum, InverterState, MultiState, SolarChargerState, TemperatureStatus, TemperatureType, DESSErrorCode, DESSRestrictions
+from ._victron_enums import DESSReactiveStrategy, DESSStrategy, DeviceType, ESSMode, FluidType, InverterMode, GenericOnOff, EvChargerMode, InverterOverloadAlarmEnum, State, MultiState, TemperatureStatus, TemperatureType, DESSErrorCode, DESSRestrictions, ErrorCode, PhoenixInverterMode
 
 # Good sources for topics is:
 # https://github.com/victronenergy/venus/wiki/dbus
@@ -318,7 +318,70 @@ topics: List[TopicDescriptor] = [
         name="Solar Charger State",
         device_type=DeviceType.SOLAR_CHARGER,
         value_type=ValueType.ENUM,
-        enum=SolarChargerState,
+        enum=State,
+    ),
+    TopicDescriptor(
+        topic="N/+/solarcharger/+/ErrorCode",
+        message_type=MetricKind.SENSOR,
+        short_id="solarcharger_error_code",
+        name="Solar Charger Error Code",
+        device_type=DeviceType.SOLAR_CHARGER,
+        value_type=ValueType.ENUM,
+        enum=ErrorCode,
+    ),
+    TopicDescriptor(
+        topic="N/+/solarcharger/+/History/Daily/0/MinBatteryVoltage",
+        message_type=MetricKind.SENSOR,
+        short_id="solarcharger_min_battery_voltage_today",
+        name="Solar Charger Min Battery Voltage Today",
+        unit_of_measurement="V",
+        metric_type=MetricType.VOLTAGE,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.SOLAR_CHARGER,
+        value_type=ValueType.FLOAT,
+        precision=2,
+    ),
+    TopicDescriptor(
+        topic="N/+/solarcharger/+/History/Daily/0/MaxBatteryVoltage",
+        message_type=MetricKind.SENSOR,
+        short_id="solarcharger_max_battery_voltage_today",
+        name="Solar Charger Max Battery Voltage Today",
+        unit_of_measurement="V",
+        metric_type=MetricType.VOLTAGE,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.SOLAR_CHARGER,
+        value_type=ValueType.FLOAT,
+        precision=2,
+    ),
+    TopicDescriptor(
+        topic="N/+/solarcharger/+/History/Daily/0/TimeInAbsorption",
+        message_type=MetricKind.SENSOR,
+        short_id="solarcharger_time_in_absorption_today",
+        name="Solar Charger Time in Absorption Today",
+        unit_of_measurement="s",
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.SOLAR_CHARGER,
+        value_type=ValueType.INT,
+    ),
+    TopicDescriptor(
+        topic="N/+/solarcharger/+/History/Daily/0/TimeInFloat",
+        message_type=MetricKind.SENSOR,
+        short_id="solarcharger_time_in_float_today",
+        name="Solar Charger Time in Float Today",
+        unit_of_measurement="s",
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.SOLAR_CHARGER,
+        value_type=ValueType.INT,
+    ),
+    TopicDescriptor(
+        topic="N/+/solarcharger/+/History/Daily/0/TimeInBulk",
+        message_type=MetricKind.SENSOR,
+        short_id="solarcharger_time_in_bulk_today",
+        name="Solar Charger Time in Bulk Today",
+        unit_of_measurement="s",
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.SOLAR_CHARGER,
+        value_type=ValueType.INT,
     ),
 
     #System
@@ -645,7 +708,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Mode",
         message_type=MetricKind.SELECT,
-        short_id="inverter_mode",
+        short_id="vebus_inverter_mode",
         name="Inverter mode",
         device_type=DeviceType.INVERTER,
         value_type=ValueType.ENUM,
@@ -654,16 +717,16 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/State",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_state",
+        short_id="vebus_inverter_state",
         name="Inverter state",
         device_type=DeviceType.INVERTER,
         value_type=ValueType.ENUM,
-        enum=InverterState,
+        enum=State,
     ),
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/ActiveIn/{phase}/V",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_input_voltage_{phase}",
+        short_id="vebus_inverter_input_voltage_{phase}",
         name="Inverter input voltage {phase}",
         unit_of_measurement="V",
         metric_type=MetricType.VOLTAGE,
@@ -675,7 +738,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/ActiveIn/{phase}/P",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_input_power_{phase}",
+        short_id="vebus_inverter_input_power_{phase}",
         name="Inverter input power {phase}",
         unit_of_measurement="W",
         metric_type=MetricType.POWER,
@@ -687,7 +750,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/ActiveIn/{phase}/F",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_input_frequency_{phase}",
+        short_id="vebus_inverter_input_frequency_{phase}",
         name="Inverter input frequency {phase}",
         unit_of_measurement="Hz",
         metric_type=MetricType.FREQUENCY,
@@ -699,7 +762,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/ActiveIn/{phase}/S",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_input_apparent_power_{phase}",
+        short_id="vebus_inverter_input_apparent_power_{phase}",
         name="Inverter input apparent power {phase}",
         unit_of_measurement="VA",
         metric_type=MetricType.POWER,
@@ -711,7 +774,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/Out/{phase}/P",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_output_power_{phase}",
+        short_id="vebus_inverter_output_power_{phase}",
         name="Inverter output power {phase}",
         unit_of_measurement="W",
         metric_type=MetricType.POWER,
@@ -723,7 +786,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/Out/{phase}/F",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_output_frequency_{phase}",
+        short_id="vebus_inverter_output_frequency_{phase}",
         name="Inverter output frequency {phase}",
         unit_of_measurement="Hz",
         metric_type=MetricType.FREQUENCY,
@@ -735,7 +798,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/Out/{phase}/S",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_output_apparent_power_{phase}",
+        short_id="vebus_inverter_output_apparent_power_{phase}",
         name="Inverter output apparent power {phase}",
         unit_of_measurement="VA",
         metric_type=MetricType.POWER,
@@ -747,7 +810,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Connected",
         message_type=MetricKind.BINARY_SENSOR,
-        short_id="inverter_connected",
+        short_id="vebus_inverter_connected",
         name="Inverter connected",
         metric_type=MetricType.NONE,
         metric_nature=MetricNature.NONE,
@@ -758,7 +821,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Alarms/Overload",
         message_type=MetricKind.SENSOR,
-        short_id="inverter_alarm_overload",
+        short_id="vebus_inverter_alarm_overload",
         name="Inverter overload alarm",
         metric_type=MetricType.NONE,
         metric_nature=MetricNature.NONE,
@@ -769,7 +832,7 @@ topics: List[TopicDescriptor] = [
     TopicDescriptor(
         topic="N/+/vebus/+/Ac/ActiveIn/CurrentLimit",
         message_type=MetricKind.NUMBER,
-        short_id="inverter_current_limit",
+        short_id="vebus_inverter_current_limit",
         name="Inverter current limit",
         unit_of_measurement="A",
         metric_type=MetricType.CURRENT,
@@ -781,6 +844,147 @@ topics: List[TopicDescriptor] = [
         max=16,
         is_adjustable_suffix = "CurrentLimitIsAdjustable"
     ),
+
+    # inverter with +/+/inverter/# in topic - e.g. Phoenix Inverter
+    TopicDescriptor(
+        topic="N/+/inverter/+/Mode",
+        message_type=MetricKind.SELECT,
+        short_id="inverter_mode",
+        name="Inverter mode",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=PhoenixInverterMode,
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/State",
+        message_type=MetricKind.SENSOR,
+        short_id="inverter_state",
+        name="Inverter state",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=State,
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Ac/Out/{phase}/V",
+        message_type=MetricKind.SENSOR,
+        short_id="inverter_output_voltage_{phase}",
+        name="Inverter output voltage {phase}",
+        unit_of_measurement="V",
+        metric_type=MetricType.VOLTAGE,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.FLOAT,
+        precision=1,
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Ac/Out/{phase}/P",
+        message_type=MetricKind.SENSOR,
+        short_id="inverter_output_power_{phase}",
+        name="Inverter output power {phase}",
+        unit_of_measurement="W",
+        metric_type=MetricType.POWER,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.FLOAT,
+        precision=1,
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Ac/Out/{phase}/S",
+        message_type=MetricKind.SENSOR,
+        short_id="inverter_output_apparent_power_{phase}",
+        name="Inverter output apparent power {phase}",
+        unit_of_measurement="VA",
+        metric_type=MetricType.POWER,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.FLOAT,
+        precision=1,
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Ac/Out/{phase}/I",
+        message_type=MetricKind.SENSOR,
+        short_id="inverter_output_current_{phase}",
+        name="Inverter output current {phase}",
+        unit_of_measurement="A",
+        metric_type=MetricType.CURRENT,
+        metric_nature=MetricNature.INSTANTANEOUS,
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.FLOAT,
+        precision=1,
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/Ripple",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_ripple",
+        name="Inverter alarm Ripple",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/LowVoltageAcOut",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_low_voltage_ac_out",
+        name="Inverter alarm LowVoltageAcOut",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/LowVoltage",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_low_voltage",
+        name="Inverter alarm LowVoltage",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/HighVoltageAcOut",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_high_voltage_ac_out",
+        name="Inverter alarm HighVoltageAcOut",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/HighTemperature",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_high_temperature",
+        name="Inverter alarm HighTemperature",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/HighVoltage",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_high_voltage",
+        name="Inverter alarm HighVoltage",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/LowTemperature",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_low_temperature",
+        name="Inverter alarm LowTemperature",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+    TopicDescriptor(
+        topic="N/+/inverter/+/Alarms/Overload",
+        message_type=MetricKind.BINARY_SENSOR,
+        short_id="inverter_alarm_overload",
+        name="Inverter alarm Overload",
+        device_type=DeviceType.INVERTER,
+        value_type=ValueType.ENUM,
+        enum=GenericOnOff
+    ),
+
     # integrated system. Note that this might not be currently accurate for all systems
     #  as there are different physical configurations
     # and don't have access to any other for testing or feedback.
@@ -1373,7 +1577,7 @@ topics: List[TopicDescriptor] = [
         metric_nature=MetricNature.NONE,
         device_type=DeviceType.MULTI_RS_SOLAR,
         value_type=ValueType.ENUM,
-        enum=InverterState,
+        enum=State,
     ),
     #multirssolar mppt {mpptnumber} pv topics
         TopicDescriptor(


### PR DESCRIPTION
- victron_enums PhoenixInverterMode and ErrorCode created
- victron_enums InverterState and SolarChargerState merged to State
- TopicDescriptor for ID's solarcharger_error_code, solarcharger_min_battery_voltage_today, solarcharger_max_battery_voltage_today, solarcharger_time_in_absorption_today, solarcharger_time_in_float_today, solarcharger_time_in_bulk_today, inverter_mode, inverter_state, inverter_output_voltage_{phase}, inverter_output_power_{phase}, inverter_output_apparent_power_{phase}, inverter_output_current_{phase}, inverter_alarm_ripple, inverter_alarm_low_voltage_ac_out, inverter_alarm_low_voltage, inverter_alarm_high_voltage_ac_out, inverter_alarm_high_temperature, inverter_alarm_high_voltage, inverter_alarm_low_temperature, and inverter_alarm_overload created.
- Changed short_id's of from "inverter_*" to "vebus_inverter_*" which come from Topic "N/+/vebus/#" to obtain unique short_id's.
- Fixed Descriptionnames of environment variables in conftest.py

Testing with victron_mqtt.utils.view_metrics and real Hardware of readonly sensors successfully.
hatch test not possible. - Always Error "TypeError: str expected, not NoneType" even though I have set the environment variables.
