### PR TITLE
Add Starter Battery Sensor

### DIFF
--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -1623,4 +1623,12 @@ topics: List[TopicDescriptor] = [
         max=60,
         experimental=True,
     ),
+    # starter battery (smartshunt)
+    TopicDescriptor(
+        topic="N/+/battery/+/Dc/1/Voltage",
+        message_type=MetricKind.SENSOR,
+        short_id="starter_battery_voltage",
+        name="Starter battery voltage",
+        metric_type=MetricType.VOLTAGE,
+    ),
 ]


### PR DESCRIPTION
This topic shows your starter battery if connected to your "Aux" input on your victron Smartshunt