### PR TITLE
fix: match named placeholders as wildcards in match_from_list

### DIFF
--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -322,6 +322,34 @@ async def test_today_message():
     assert metric is not None, "Metric should exist in the device"
     assert metric.value == 2, f"Expected metric value to be 2, got {metric.value}"
 
+
+@pytest.mark.asyncio
+async def test_parameterized_topic_with_shared_map_key():
+    """Test that topics with a named placeholder (e.g. {mppt_id}) are matched correctly
+    when they share a topic-map key with another descriptor (e.g. Daily/0 vs Daily/1).
+    Previously match_from_list only did exact matching, so {mppt_id} never matched a
+    concrete value like 0 and the message was silently dropped."""
+    hub: Hub = await create_mocked_hub()
+
+    await inject_message(hub, "N/123/multi/0/History/Daily/0/Pv/0/Yield", "{\"value\": 9.5}")
+    await inject_message(hub, "N/123/multi/0/History/Daily/0/Pv/1/Yield", "{\"value\": 2.5}")
+    await inject_message(hub, "N/123/multi/0/History/Daily/1/Pv/0/Yield", "{\"value\": 7.0}")
+    await finalize_injection(hub)
+
+    device = hub.devices["multi_0"]
+    metric = device.get_metric("multi_mppt_0_yield_today")
+    assert metric is not None, "multi_mppt_0_yield_today should be created"
+    assert metric.value == 9.5
+
+    metric = device.get_metric("multi_mppt_1_yield_today")
+    assert metric is not None, "multi_mppt_1_yield_today should be created"
+    assert metric.value == 2.5
+
+    metric = device.get_metric("multi_mppt_0_yield_yesterday")
+    assert metric is not None, "multi_mppt_0_yield_yesterday should be created"
+    assert metric.value == 7.0
+
+
 def test_expend_topics():
     """Test that the Hub correctly expands topic descriptors with placeholders."""
     descriptor = next((t for t in topics if t.topic == "N/{installation_id}/switch/{device_id}/SwitchableOutput/output_{output(1-4)}/State"), None)

--- a/victron_mqtt/data_classes.py
+++ b/victron_mqtt/data_classes.py
@@ -307,14 +307,34 @@ class ParsedTopic:
     # This is needed in cases of solarcharger_max_power_today and solarcharger_max_power_yesterday
     # which has the same topic but different meaning
     def match_from_list(self, topic_desc_list: list[TopicDescriptor]) -> TopicDescriptor | None:
-        """Match the ParsedTopic to a TopicDescriptor from a list."""
+        """Match the ParsedTopic to a TopicDescriptor from a list.
+
+        First tries an exact match (after normalising installation_id and device_id).
+        Falls back to a wildcard match where {placeholder} parts in the descriptor
+        match any concrete value in the incoming topic.
+        """
         topic_parts = self.full_topic.split("/")
         topic_parts[1] = "{installation_id}"
         topic_parts[3] = "{device_id}"
         normalized_topic = "/".join(topic_parts)
+
+        # Pass 1: exact match (e.g. Daily/0/Yield vs Daily/1/Yield)
         for topic_desc in topic_desc_list:
             if topic_desc.topic == normalized_topic:
                 return topic_desc
+
+        # Pass 2: wildcard match — {placeholder} in descriptor matches any value
+        # (e.g. Daily/0/Pv/{mppt_id}/Yield matches Daily/0/Pv/0/Yield)
+        for topic_desc in topic_desc_list:
+            desc_parts = topic_desc.topic.split("/")
+            if len(desc_parts) != len(topic_parts):
+                continue
+            if all(
+                dp == ip or (dp.startswith("{") and dp.endswith("}"))
+                for dp, ip in zip(desc_parts, topic_parts)
+            ):
+                return topic_desc
+
         return None
 
     @property


### PR DESCRIPTION
## Problem

Topics like `History/Daily/0/Pv/{mppt_id}/Yield` and `History/Daily/1/Pv/{mppt_id}/Yield` share the same topic-map key because `_remove_placeholders_map` normalises both literal digits **and** `{placeholder}` tokens to `##num##`.

The old `match_from_list` only did exact string matching, so `{mppt_id}` never matched a concrete value (e.g. `0`) and all such messages were silently dropped — no entity was ever created for multi MPPT yield metrics, even though the Cerbo GX publishes the data correctly.

## Fix

Add a second pass to `match_from_list` that treats `{placeholder}` tokens as wildcards. Exact matches still win via pass 1 (preserving today/yesterday disambiguation like `Daily/0` vs `Daily/1`). The wildcard pass is only reached when no exact match exists.

## Test

Added `test_parameterized_topic_with_shared_map_key` which:
- injects `Daily/0/Pv/0/Yield`, `Daily/0/Pv/1/Yield`, and `Daily/1/Pv/0/Yield` messages
- asserts that `multi_mppt_0_yield_today`, `multi_mppt_1_yield_today`, and `multi_mppt_0_yield_yesterday` metrics are created with correct values
- confirmed the test **fails** on the unpatched code (device never created) and **passes** after the fix

## Test plan
- [x] New regression test passes
- [x] Full `tests/static_hub_test.py` suite (117 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)