### PR TITLE
Add ess max charge power topic

### DIFF
--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -1783,6 +1783,17 @@ topics: list[TopicDescriptor] = [
         enum=ESSModeHub4,
     ),
     TopicDescriptor(
+        topic="N/{installation_id}/settings/{device_id}/Settings/CGwacs/MaxChargePower",
+        message_type=MetricKind.NUMBER,
+        short_id="system_ess_max_charge_power",
+        name="ESS max charge power limit",
+        metric_type=MetricType.POWER,
+        value_type=ValueType.INT,
+        min_max_range=RangeType.DYNAMIC,
+        min=-1,
+        max=1000000,
+    ),
+    TopicDescriptor(
         topic="N/{installation_id}/settings/{device_id}/Settings/CGwacs/MaxDischargePower",
         message_type=MetricKind.NUMBER,
         short_id="system_ess_max_inverter_power_limit",


### PR DESCRIPTION
Got these from MQTT Explorer on my installation. Similar to MaxDischargePower and MaxFeedInPower.


{"max":1000000.0,"min":-1.0,"value":55.0}
N/{installation-id}/settings/0/Settings/CGwacs/MaxChargePower
