### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-ha-core.yml
+++ b/.github/workflows/update-ha-core.yml
@@ -3,6 +3,9 @@ name: Update Home Assistant Core Integration
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-ha-core:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tomer-w/victron_mqtt/security/code-scanning/5](https://github.com/tomer-w/victron_mqtt/security/code-scanning/5)

Add an explicit top-level `permissions` block to `.github/workflows/update-ha-core.yml` so the workflow does not inherit potentially broad defaults.  
Best fix without changing functionality: define minimal read access for `GITHUB_TOKEN` at workflow scope:

- `contents: read`

This satisfies CodeQL’s requirement and keeps behavior unchanged, since write actions in this workflow already use `secrets.HA_CORE_PAT` explicitly.  
Edit location: directly after the `on:` block (after `workflow_dispatch:`) and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
