### PR TITLE
Serialize integer settings as int, not float

### DIFF
--- a/tests/test_unwrappers.py
+++ b/tests/test_unwrappers.py
@@ -392,3 +392,14 @@ class TestVictronEnumFunctions:
         assert GenericOnOff.from_id_or_string("On") is GenericOnOff.ON
         with pytest.raises(ValueError, match="No enum member found with id or string=does-not-exist"):
             GenericOnOff.from_id_or_string("does-not-exist")
+
+
+def test_wrap_int_coerces_float_to_int():
+    """wrap_int* must serialize integers, even when given a float (HA NumberEntity passes float)."""
+    assert wrap_int(10.0) == '{"value": 10}'
+    assert wrap_int(11) == '{"value": 11}'
+    assert wrap_int(None) == '{"value": null}'
+    assert wrap_int_default_0(3.0) == '{"value": 3}'
+    assert wrap_int_default_0(None) == '{"value": 0}'
+    assert wrap_int_hours_to_seconds(2.0) == '{"value": 7200}'
+    assert wrap_int_minutes_to_seconds(5.0) == '{"value": 300}'

--- a/victron_mqtt/_unwrappers.py
+++ b/victron_mqtt/_unwrappers.py
@@ -151,24 +151,24 @@ def wrap_bitmask(
     return json.dumps({"value": val})
 
 
-def wrap_int(value: int | None) -> str:
+def wrap_int(value: int | float | None) -> str:
     """Wrap an integer value into a JSON string with a 'value' key."""
-    return json.dumps({"value": value})
+    return json.dumps({"value": int(value) if value is not None else None})
 
 
-def wrap_int_hours_to_seconds(value: int | None) -> str:
+def wrap_int_hours_to_seconds(value: int | float | None) -> str:
     """Wrap an integer value into a JSON string with a 'value' key."""
-    return json.dumps({"value": value * 3600 if value is not None else None})
+    return json.dumps({"value": int(value) * 3600 if value is not None else None})
 
 
-def wrap_int_minutes_to_seconds(value: int | None) -> str:
+def wrap_int_minutes_to_seconds(value: int | float | None) -> str:
     """Wrap an integer value into a JSON string with a 'value' key."""
-    return json.dumps({"value": value * 60 if value is not None else None})
+    return json.dumps({"value": int(value) * 60 if value is not None else None})
 
 
-def wrap_int_default_0(value: int | None) -> str:
+def wrap_int_default_0(value: int | float | None) -> str:
     """Wrap an integer value into a JSON string with a 'value' key, defaulting to 0 if None."""
-    return json.dumps({"value": value if value is not None else 0})
+    return json.dumps({"value": int(value) if value is not None else 0})
 
 
 def wrap_float(value: float | None) -> str:


### PR DESCRIPTION
## What
`wrap_int`, `wrap_int_hours_to_seconds`, `wrap_int_minutes_to_seconds` and `wrap_int_default_0` now coerce their value to `int` before JSON-serializing. `wrap_float` is unchanged.

## Why
Home Assistant's `NumberEntity` hands a `float` to `WritableMetric.set()`, so writing an integer setting produced `{"value": 10.0}` instead of `{"value": 10}`. That's asymmetric with `unwrap_int`, which already reads via `int(...)`. My GX (Venus on a Raspberry Pi) tolerates the float, but a proper int matches the descriptor's `ValueType.INT` and avoids trouble on stricter settings/firmware.

## How tested
Reproduced live on a Venus install via the `Settings/CGwacs/AcExportLimit` number entity: before the change the broker received `{"value": 10.0}`; after it, `{"value": 10}`, accepted by the GX (the `N/...` topic echoes `10`). Added unit tests in `tests/test_unwrappers.py` covering the coercion (including `None` and the seconds-conversion helpers).
