### PR TITLE
feat: add disabled_by_default for per-tracker/MPPT entities

### DIFF
--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -2044,6 +2044,7 @@ topics: list[TopicDescriptor] = [
         short_id="multi_mppt_{mppt_id}_yield_today",
         name="MPPT {mppt_id} yield today",
         metric_type=MetricType.ENERGY,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/multi/{device_id}/History/Daily/0/Yield",
@@ -2065,6 +2066,7 @@ topics: list[TopicDescriptor] = [
         short_id="multi_mppt_{mppt_id}_yield_yesterday",
         name="MPPT {mppt_id} yield yesterday",
         metric_type=MetricType.ENERGY,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/multi/{device_id}/History/Daily/1/Yield",
@@ -2081,6 +2083,7 @@ topics: list[TopicDescriptor] = [
         value_type=ValueType.ENUM,
         enum=MppOperationMode,
         main_topic=True,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/multi/{device_id}/Pv/{mpptnumber}/P",
@@ -2088,6 +2091,7 @@ topics: list[TopicDescriptor] = [
         short_id="multi_mppt_{mpptnumber}_power",
         name="MPPT {mpptnumber} power",
         metric_type=MetricType.POWER,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/multi/{device_id}/Pv/{mpptnumber}/V",
@@ -2095,6 +2099,7 @@ topics: list[TopicDescriptor] = [
         short_id="multi_mppt_{mpptnumber}_voltage",
         name="MPPT {mpptnumber} PV voltage",
         metric_type=MetricType.VOLTAGE,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="$$func/multi/pv_current",
@@ -2104,6 +2109,7 @@ topics: list[TopicDescriptor] = [
         metric_type=MetricType.CURRENT,
         precision=2,
         depends_on=["multi_mppt_{mpptnumber}_power", "multi_mppt_{mpptnumber}_voltage"],
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/multi/{device_id}/Relay/0/State",
@@ -2777,6 +2783,7 @@ topics: list[TopicDescriptor] = [
         short_id="solarcharger_tracker_{tracker}_max_power_today",
         name="Tracker {tracker:solarcharger_tracker_{tracker}_name} max power today",
         metric_type=MetricType.POWER,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/History/Daily/0/Pv/{tracker}/MaxVoltage",
@@ -2784,6 +2791,7 @@ topics: list[TopicDescriptor] = [
         short_id="solarcharger_tracker_{tracker}_max_voltage_today",
         name="Tracker {tracker:solarcharger_tracker_{tracker}_name} max voltage today",
         metric_type=MetricType.VOLTAGE,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/History/Daily/0/Pv/{tracker}/Yield",
@@ -2791,6 +2799,7 @@ topics: list[TopicDescriptor] = [
         short_id="solarcharger_tracker_{tracker}_yield_today",
         name="Tracker {tracker:solarcharger_tracker_{tracker}_name} yield today",
         metric_type=MetricType.ENERGY,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/History/Daily/0/TimeInAbsorption",
@@ -2888,6 +2897,7 @@ topics: list[TopicDescriptor] = [
         name="PV tracker {tracker:solarcharger_tracker_{tracker}_name} operation mode",
         value_type=ValueType.ENUM,
         enum=MppOperationMode,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/Pv/{tracker}/Name",
@@ -2895,6 +2905,7 @@ topics: list[TopicDescriptor] = [
         short_id="solarcharger_tracker_{tracker}_name",
         name="PV tracker {tracker} name",
         value_type=ValueType.STRING,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/Pv/{tracker}/P",
@@ -2902,6 +2913,7 @@ topics: list[TopicDescriptor] = [
         short_id="solarcharger_tracker_{tracker}_power",
         name="PV tracker {tracker:solarcharger_tracker_{tracker}_name} power",
         metric_type=MetricType.POWER,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/Pv/{tracker}/V",
@@ -2909,6 +2921,7 @@ topics: list[TopicDescriptor] = [
         short_id="solarcharger_tracker_{tracker}_voltage",
         name="PV tracker {tracker:solarcharger_tracker_{tracker}_name} voltage",
         metric_type=MetricType.VOLTAGE,
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="$$func/solarcharger/pv_current",
@@ -2918,6 +2931,7 @@ topics: list[TopicDescriptor] = [
         metric_type=MetricType.CURRENT,
         precision=2,
         depends_on=["solarcharger_tracker_{tracker}_power", "solarcharger_tracker_{tracker}_voltage"],
+        disabled_by_default=True,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/solarcharger/{device_id}/Relay/0/State",

--- a/victron_mqtt/data_classes.py
+++ b/victron_mqtt/data_classes.py
@@ -85,6 +85,7 @@ class TopicDescriptor:
     is_formula: bool = False  # True if this topic is calculated from other topics
     main_topic: bool = False  # True if this topic is the main topic for the dvice. Not all devices has to have main entity, but if it has, it should be the one with main_topic = True.
     hidden: bool = False  # When True, the metric is excluded from on_new_metric callbacks
+    disabled_by_default: bool = False  # When True, entity is created but disabled in HA by default
     sub_device_key: str | None = (
         None  # When set, topics with this field create a separate sub-device per unique placeholder value (e.g., "output" creates sub-devices per output ID)
     )

--- a/victron_mqtt/metric.py
+++ b/victron_mqtt/metric.py
@@ -193,6 +193,11 @@ class Metric:
         return self._descriptor.main_topic
 
     @property
+    def disabled_by_default(self) -> bool:
+        """Returns whether the entity should be disabled by default in HA."""
+        return self._descriptor.disabled_by_default
+
+    @property
     def unique_id(self) -> str:
         """Return the unique id of the metric."""
         return self._unique_id


### PR DESCRIPTION
Addresses the per-tracker entity explosion raised in #103.

Multi-tracker chargers (e.g. SmartSolar MPPT RS 450/200 with 4 PV trackers) produce ~7 entities per tracker × N trackers, all refreshing on every keepalive cycle. That's potentially hundreds of continuously-recorded entities on installations with several such chargers — most users only ever look at the device-level totals.

**What this PR does:**

Adds a `disabled_by_default: bool = False` field to `TopicDescriptor` and a matching `disabled_by_default` property on `Metric`. Marks all per-tracker and per-MPPT entities with `disabled_by_default=True`:

- `solarcharger`: 8 entities (`tracker_{n}_power`, `_voltage`, `_current`, `_operation_mode`, `_name`, `_max_power_today`, `_max_voltage_today`, `_yield_today`)
- `multi`: 6 entities (`mppt_{n}_yield_today`, `_yield_yesterday`, `_state`, `_power`, `_voltage`, `_current`)

**Safe for existing installations:**

`disabled_by_default` is a flag on newly created entities only. Any entity already in a user's registry keeps its current enabled/disabled state untouched — no history, no automations, no unique_ids are affected.

Users who want the per-tracker breakdown can enable the entities individually in HA, just like any other disabled-by-default entity.

The integration side (using `metric.disabled_by_default` to set `entity_registry_enabled_default`) is a small follow-up in `ha-victron-mqtt`.