### PR TITLE
Fix paho-mqtt minimum version and relax Python requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "victron_mqtt"
 version = "2026.7.2"
 description = "Python library for communicating with Victron Venus OS MQTT interface"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 license = "MIT"
 keywords = ["victron", "mqtt", "venus os"]
 authors = [
@@ -16,12 +16,14 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "paho-mqtt>=1.6.1",
+  "paho-mqtt>=2.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -95,7 +97,7 @@ exclude_lines = [
 [tool.ruff]
 exclude = [".git", "__pycache__", "node_modules", "public", "venv"]
 line-length = 120
-target-version = "py313"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

Two packaging fixes in `pyproject.toml`:

- **`paho-mqtt>=1.6.1` → `paho-mqtt>=2.0`.** The code uses the paho v2 callback API (`CallbackAPIVersion.VERSION2`, `from paho.mqtt.enums import ...`, `ConnectFlags`/`DisconnectFlags`), none of which exist in paho 1.x — with paho 1.6 installed the import fails at load time, so the declared minimum was effectively wrong.
- **`requires-python >=3.13` → `>=3.11`.** The newest constructs in the codebase are `asyncio.timeout`, `datetime.UTC` and `typing.Self`, all available since 3.11, so the 3.13 floor excludes users unnecessarily. Classifiers for 3.11/3.12 added and ruff's `target-version` aligned so the linter doesn't suggest syntax above the new floor.

## Testing

- Full static test suite (229 tests) passes in a clean venv resolving paho-mqtt 2.1.0.
- 3.11 compatibility verified by API review (no 3.12+ features found); CI currently only exercises 3.13 — happy to add a 3.11/3.12/3.13 matrix in a follow-up if you want the range guaranteed by CI.