### PR TITLE
Add "auto" update frequency with per-metric-type intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ hub = victron_mqtt.Hub(
 - `0` — deliver on every MQTT message, even if the value is unchanged
 - `N > 0` — deliver at most one update per `N` seconds per metric
 - `"auto"` — per-metric interval chosen by the library based on the metric type: fast-changing metrics users watch live (power, current) update every few seconds, while the rest use a longer interval. See `AUTO_UPDATE_INTERVALS` in `victron_mqtt.constants`.
+- `"auto_power_none"` — like `"auto"`, but fast-changing metrics update on every value change with no time limit.
 
 **Key properties:**
 - `hub.devices` — dict of all devices with visible metrics

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ hub = victron_mqtt.Hub(
 > hub = victron_mqtt.Hub("venus.local.", 8883, None, "password", True, ssl_context=context)
 > ```
 
+**Update frequency:** `update_frequency_seconds` controls how often metric updates are delivered to `on_update` callbacks. Throttling only applies to numeric values; non-numeric changes are always delivered.
+- `None` (default) — deliver on every value change
+- `0` — deliver on every MQTT message, even if the value is unchanged
+- `N > 0` — deliver at most one update per `N` seconds per metric
+- `"auto"` — per-metric interval chosen by the library based on the metric type: fast-changing metrics users watch live (power, current) update every few seconds, while the rest use a longer interval. See `AUTO_UPDATE_INTERVALS` in `victron_mqtt.constants`.
+
 **Key properties:**
 - `hub.devices` — dict of all devices with visible metrics
 - `hub.installation_id` — the Venus OS installation identifier

--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -621,6 +621,55 @@ async def test_same_message_events_auto(mock_time: MagicMock) -> None:
 
 
 @pytest.mark.asyncio
+@patch("victron_mqtt.metric.time.monotonic")
+async def test_same_message_events_auto_power_none(mock_time: MagicMock) -> None:
+    """Test that "auto_power_none" removes the time limit for fast-changing metrics."""
+
+    mock_time.return_value = 0.0
+    hub: Hub = await create_mocked_hub(update_frequency_seconds="auto_power_none")
+
+    mock_time.return_value = 10
+
+    # Inject messages after the event is set
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 100}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 42}', mock_time)
+    await finalize_injection(hub, False, mock_time)
+
+    # Validate that the device has the metrics we published
+    device = hub.devices["grid_30"]
+    power_metric = device.get_metric("grid_power_l1")
+    energy_metric = device.get_metric("grid_energy_forward_l1")
+    assert power_metric is not None, "Power metric should exist in the device"
+    assert energy_metric is not None, "Energy metric should exist in the device"
+    assert power_metric.update_interval_seconds is None, "Power metrics should have no time limit"
+    assert energy_metric.update_interval_seconds == 30, "Energy metrics should use the default auto interval"
+    power_metric.on_update = MagicMock()
+    energy_metric.on_update = MagicMock()
+
+    mock_time.return_value = 11
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 101}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 43}', mock_time)
+    assert power_metric.on_update.call_count == 1, "on_update should be called for the first notification"
+    assert energy_metric.on_update.call_count == 1, "on_update should be called for the first notification"
+
+    mock_time.return_value = 12
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 102}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 44}', mock_time)
+    assert power_metric.on_update.call_count == 2, "on_update should be called on every power value change"
+    assert energy_metric.on_update.call_count == 1, "on_update should not be called before the energy interval elapsed"
+
+    mock_time.return_value = 13
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 102}', mock_time)
+    assert power_metric.on_update.call_count == 2, "on_update should not be called when the power value is unchanged"
+
+    mock_time.return_value = 45
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 45}', mock_time)
+    assert energy_metric.on_update.call_count == 2, "on_update should be called after the energy interval elapsed"
+
+    await hub_disconnect(hub, mock_time)
+
+
+@pytest.mark.asyncio
 async def test_invalid_update_frequency():
     """Test that the Hub rejects invalid update_frequency_seconds values."""
     with pytest.raises(ValueError, match="update_frequency_seconds"):

--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -21,7 +21,15 @@ from victron_mqtt._victron_formulas import (
     schedule_charge_enabled_set,
 )
 from victron_mqtt._victron_topics import topics
-from victron_mqtt.constants import MetricKind, MetricNature, MetricType, OperationMode, ValueType
+from victron_mqtt.constants import (
+    AUTO_UPDATE_INTERVAL_DEFAULT,
+    AUTO_UPDATE_INTERVALS,
+    MetricKind,
+    MetricNature,
+    MetricType,
+    OperationMode,
+    ValueType,
+)
 from victron_mqtt.data_classes import ParsedTopic, TopicDescriptor
 from victron_mqtt.device import Device, FallbackPlaceholder
 from victron_mqtt.formula_common import LRSLastReading
@@ -2434,6 +2442,13 @@ def _make_metric(
     m._last_seen = 0.0
     m._last_notified = 0.0
     m._depend_on_me = []
+    frequency = hub._update_frequency_seconds
+    if isinstance(frequency, str):
+        m._update_interval_seconds = AUTO_UPDATE_INTERVALS[frequency].get(
+            descriptor.metric_type, AUTO_UPDATE_INTERVAL_DEFAULT
+        )
+    else:
+        m._update_interval_seconds = frequency
     return m
 
 
@@ -2932,6 +2947,7 @@ class TestWritableFormulaMetricKeepalive:
         wfm._last_seen = 0.0
         wfm._last_notified = 0.0
         wfm._depend_on_me = []
+        wfm._update_interval_seconds = 0
 
         wfm._keepalive(force_invalidate=False, log_debug=log)
         log.assert_called()
@@ -2964,6 +2980,7 @@ class TestWritableFormulaMetricSet:
         wfm._last_seen = 0.0
         wfm._last_notified = 0.0
         wfm._depend_on_me = []
+        wfm._update_interval_seconds = 0
         wfm._func = MagicMock()
         wfm._write_func = write_func
         wfm._depends_on = {}
@@ -3007,6 +3024,7 @@ class TestFormulaMetricNoneReturn:
         fm._last_seen = 0.0
         fm._last_notified = 0.0
         fm._depend_on_me = []
+        fm._update_interval_seconds = 0
         fm._func = formula_none
         fm._depends_on = {}
         fm.transient_state = None

--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -569,6 +569,73 @@ async def test_same_message_events_five(mock_time: MagicMock) -> None:
 
 @pytest.mark.asyncio
 @patch("victron_mqtt.metric.time.monotonic")
+async def test_same_message_events_auto(mock_time: MagicMock) -> None:
+    """Test per-metric-type update intervals when update_frequency_seconds is "auto"."""
+
+    mock_time.return_value = 0.0
+    hub: Hub = await create_mocked_hub(update_frequency_seconds="auto")
+
+    mock_time.return_value = 10
+
+    # Inject messages after the event is set
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 100}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 42}', mock_time)
+    await finalize_injection(hub, False, mock_time)
+
+    # Validate that the device has the metrics we published
+    device = hub.devices["grid_30"]
+    power_metric = device.get_metric("grid_power_l1")
+    energy_metric = device.get_metric("grid_energy_forward_l1")
+    assert power_metric is not None, "Power metric should exist in the device"
+    assert energy_metric is not None, "Energy metric should exist in the device"
+    assert power_metric.update_interval_seconds == 5, "Power metrics should use the fast auto interval"
+    assert energy_metric.update_interval_seconds == 30, "Energy metrics should use the default auto interval"
+    power_metric.on_update = MagicMock()
+    energy_metric.on_update = MagicMock()
+
+    mock_time.return_value = 11
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 101}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 43}', mock_time)
+    assert power_metric.on_update.call_count == 1, "on_update should be called for the first notification"
+    assert energy_metric.on_update.call_count == 1, "on_update should be called for the first notification"
+
+    mock_time.return_value = 13
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 102}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 44}', mock_time)
+    assert power_metric.on_update.call_count == 1, "on_update should not be called before the power interval elapsed"
+    assert energy_metric.on_update.call_count == 1, "on_update should not be called before the energy interval elapsed"
+
+    mock_time.return_value = 17
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 103}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 45}', mock_time)
+    assert power_metric.on_update.call_count == 2, "on_update should be called after the power interval elapsed"
+    assert energy_metric.on_update.call_count == 1, "on_update should not be called before the energy interval elapsed"
+
+    mock_time.return_value = 45
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Power", '{"value": 104}', mock_time)
+    await inject_message(hub, "N/123/grid/30/Ac/L1/Energy/Forward", '{"value": 46}', mock_time)
+    assert power_metric.on_update.call_count == 3, "on_update should be called after the power interval elapsed"
+    assert energy_metric.on_update.call_count == 2, "on_update should be called after the energy interval elapsed"
+
+    await hub_disconnect(hub, mock_time)
+
+
+@pytest.mark.asyncio
+async def test_invalid_update_frequency():
+    """Test that the Hub rejects invalid update_frequency_seconds values."""
+    with pytest.raises(ValueError, match="update_frequency_seconds"):
+        Hub(
+            host="localhost",
+            port=1883,
+            username=None,
+            password=None,
+            use_ssl=False,
+            update_frequency_seconds="fast",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+@patch("victron_mqtt.metric.time.monotonic")
 async def test_metric_keepalive_update_frequency_5(mock_time: MagicMock) -> None:
     """Test that the Hub correctly updates its internal state based on MQTT messages."""
     mock_time.return_value = 0

--- a/victron_mqtt/__init__.py
+++ b/victron_mqtt/__init__.py
@@ -52,6 +52,7 @@ from ._victron_products import ProductCapabilities, get_product_capabilities
 from .constants import (
     AUTO_UPDATE_INTERVALS,
     UPDATE_FREQUENCY_AUTO,
+    UPDATE_FREQUENCY_AUTO_POWER_NONE,
     MetricKind,
     MetricNature,
     MetricType,
@@ -77,6 +78,7 @@ from .writable_metric import WritableMetric
 __all__ = [
     "AUTO_UPDATE_INTERVALS",
     "UPDATE_FREQUENCY_AUTO",
+    "UPDATE_FREQUENCY_AUTO_POWER_NONE",
     "ACActiveInputSource",
     "ACSystemMode",
     "AcInputTypeEnum",

--- a/victron_mqtt/__init__.py
+++ b/victron_mqtt/__init__.py
@@ -49,7 +49,16 @@ from ._victron_enums import (
     VrmPortalMode,
 )
 from ._victron_products import ProductCapabilities, get_product_capabilities
-from .constants import MetricKind, MetricNature, MetricType, OperationMode, RangeType, VictronEnum
+from .constants import (
+    AUTO_UPDATE_INTERVALS,
+    UPDATE_FREQUENCY_AUTO,
+    MetricKind,
+    MetricNature,
+    MetricType,
+    OperationMode,
+    RangeType,
+    VictronEnum,
+)
 from .data_classes import GpsLocation, ProductCapabilityRef
 from .device import Device
 from .formula_metric import FormulaMetric
@@ -66,6 +75,8 @@ from .metric import Metric
 from .writable_metric import WritableMetric
 
 __all__ = [
+    "AUTO_UPDATE_INTERVALS",
+    "UPDATE_FREQUENCY_AUTO",
     "ACActiveInputSource",
     "ACSystemMode",
     "AcInputTypeEnum",

--- a/victron_mqtt/constants.py
+++ b/victron_mqtt/constants.py
@@ -71,14 +71,17 @@ class MetricType(Enum):
 
 
 UPDATE_FREQUENCY_AUTO: Final = "auto"
+UPDATE_FREQUENCY_AUTO_POWER_NONE: Final = "auto_power_none"
 
-# Per-metric-type update intervals applied when update_frequency_seconds is
-# UPDATE_FREQUENCY_AUTO. Fast-changing metrics that users watch live get a short
-# interval; every other metric type falls back to AUTO_UPDATE_INTERVAL_DEFAULT.
-AUTO_UPDATE_INTERVALS: dict[MetricType, int] = {
-    MetricType.POWER: 5,
-    MetricType.APPARENT_POWER: 5,
-    MetricType.CURRENT: 5,
+# Fast-changing metric types that users typically watch live.
+_FAST_METRIC_TYPES: Final = (MetricType.POWER, MetricType.APPARENT_POWER, MetricType.CURRENT)
+
+# Per-metric-type update intervals for each auto profile. None means no time
+# limit (update on every value change); metric types not listed fall back to
+# AUTO_UPDATE_INTERVAL_DEFAULT.
+AUTO_UPDATE_INTERVALS: dict[str, dict[MetricType, int | None]] = {
+    UPDATE_FREQUENCY_AUTO: dict.fromkeys(_FAST_METRIC_TYPES, 5),
+    UPDATE_FREQUENCY_AUTO_POWER_NONE: dict.fromkeys(_FAST_METRIC_TYPES, None),
 }
 AUTO_UPDATE_INTERVAL_DEFAULT = 30
 

--- a/victron_mqtt/constants.py
+++ b/victron_mqtt/constants.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Self
+from typing import Final, Self
 
 TOPIC_INSTALLATION_ID = "N/+/system/0/Serial"
 
@@ -68,6 +68,19 @@ class MetricType(Enum):
     CONNECTIVITY = "connectivity"
     RESTART = "restart"
     LOW_BATTERY = "low_battery"
+
+
+UPDATE_FREQUENCY_AUTO: Final = "auto"
+
+# Per-metric-type update intervals applied when update_frequency_seconds is
+# UPDATE_FREQUENCY_AUTO. Fast-changing metrics that users watch live get a short
+# interval; every other metric type falls back to AUTO_UPDATE_INTERVAL_DEFAULT.
+AUTO_UPDATE_INTERVALS: dict[MetricType, int] = {
+    MetricType.POWER: 5,
+    MetricType.APPARENT_POWER: 5,
+    MetricType.CURRENT: 5,
+}
+AUTO_UPDATE_INTERVAL_DEFAULT = 30
 
 
 class ValueType(Enum):

--- a/victron_mqtt/hub.py
+++ b/victron_mqtt/hub.py
@@ -10,7 +10,7 @@ import string
 import time
 from collections.abc import Callable
 from dataclasses import replace
-from typing import Any
+from typing import Any, Literal
 
 import paho.mqtt.client as mqtt
 from paho.mqtt.client import Client as MQTTClient
@@ -21,7 +21,7 @@ from paho.mqtt.reasoncodes import ReasonCode
 
 from ._victron_enums import DeviceType
 from ._victron_topics import topics
-from .constants import TOPIC_INSTALLATION_ID, MetricKind, OperationMode
+from .constants import TOPIC_INSTALLATION_ID, UPDATE_FREQUENCY_AUTO, MetricKind, OperationMode
 from .data_classes import ParsedTopic, TopicDescriptor, topic_to_device_type
 from .device import Device, FallbackPlaceholder, MetricPlaceholder
 from .formula_metric import FormulaMetric
@@ -96,7 +96,7 @@ class Hub:
         topic_log_info: str | None = None,
         operation_mode: OperationMode = OperationMode.FULL,
         device_type_exclude_filter: list[DeviceType] | None = None,
-        update_frequency_seconds: int | None = None,
+        update_frequency_seconds: int | Literal["auto"] | None = None,
         ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """
@@ -133,11 +133,14 @@ class Hub:
             EXPERIMENTAL).
         device_type_exclude_filter: list[DeviceType] | None
             Optional list of device types to exclude from subscriptions.
-        update_frequency_seconds: int | None
+        update_frequency_seconds: int | "auto" | None
             Optional update frequency used by metrics.
             if None = Update only when source data change
             if 0 = Update as new mqtt data received
             if > 0 = Update no more than specified interval (in seconds)
+            if "auto" = Per-metric interval chosen by the library based on the
+            metric type (see AUTO_UPDATE_INTERVALS): fast-changing metrics such
+            as power and current update more often than the rest.
         ssl_context: ssl.SSLContext | None
             Custom SSL context for the TLS connection. Provide a context with
             your CA loaded (e.g. `ssl.create_default_context(cafile=...)`) to
@@ -181,6 +184,12 @@ class Hub:
             raise ValueError("port must be an integer between 1 and 65535")
         if ssl_context is not None and not use_ssl:
             raise ValueError("ssl_context requires use_ssl=True")
+        if (
+            update_frequency_seconds is not None
+            and not isinstance(update_frequency_seconds, int)
+            and update_frequency_seconds != UPDATE_FREQUENCY_AUTO
+        ):
+            raise ValueError(f'update_frequency_seconds must be an int, None or "{UPDATE_FREQUENCY_AUTO}"')
         _LOGGER.info(
             "Initializing Hub[ID: %d](host=%s, port=%d, username=%s, use_ssl=%s, installation_id=%s, model_name=%s, topic_prefix=%s, operation_mode=%s, device_type_exclude_filter=%s, update_frequency_seconds=%s, topic_log_info=%s)",
             self._instance_id,

--- a/victron_mqtt/hub.py
+++ b/victron_mqtt/hub.py
@@ -21,7 +21,7 @@ from paho.mqtt.reasoncodes import ReasonCode
 
 from ._victron_enums import DeviceType
 from ._victron_topics import topics
-from .constants import TOPIC_INSTALLATION_ID, UPDATE_FREQUENCY_AUTO, MetricKind, OperationMode
+from .constants import AUTO_UPDATE_INTERVALS, TOPIC_INSTALLATION_ID, MetricKind, OperationMode
 from .data_classes import ParsedTopic, TopicDescriptor, topic_to_device_type
 from .device import Device, FallbackPlaceholder, MetricPlaceholder
 from .formula_metric import FormulaMetric
@@ -96,7 +96,7 @@ class Hub:
         topic_log_info: str | None = None,
         operation_mode: OperationMode = OperationMode.FULL,
         device_type_exclude_filter: list[DeviceType] | None = None,
-        update_frequency_seconds: int | Literal["auto"] | None = None,
+        update_frequency_seconds: int | Literal["auto", "auto_power_none"] | None = None,
         ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """
@@ -133,7 +133,7 @@ class Hub:
             EXPERIMENTAL).
         device_type_exclude_filter: list[DeviceType] | None
             Optional list of device types to exclude from subscriptions.
-        update_frequency_seconds: int | "auto" | None
+        update_frequency_seconds: int | "auto" | "auto_power_none" | None
             Optional update frequency used by metrics.
             if None = Update only when source data change
             if 0 = Update as new mqtt data received
@@ -141,6 +141,8 @@ class Hub:
             if "auto" = Per-metric interval chosen by the library based on the
             metric type (see AUTO_UPDATE_INTERVALS): fast-changing metrics such
             as power and current update more often than the rest.
+            if "auto_power_none" = Like "auto", but fast-changing metrics update
+            on every value change with no time limit.
         ssl_context: ssl.SSLContext | None
             Custom SSL context for the TLS connection. Provide a context with
             your CA loaded (e.g. `ssl.create_default_context(cafile=...)`) to
@@ -187,9 +189,9 @@ class Hub:
         if (
             update_frequency_seconds is not None
             and not isinstance(update_frequency_seconds, int)
-            and update_frequency_seconds != UPDATE_FREQUENCY_AUTO
+            and update_frequency_seconds not in AUTO_UPDATE_INTERVALS
         ):
-            raise ValueError(f'update_frequency_seconds must be an int, None or "{UPDATE_FREQUENCY_AUTO}"')
+            raise ValueError(f"update_frequency_seconds must be an int, None or one of {sorted(AUTO_UPDATE_INTERVALS)}")
         _LOGGER.info(
             "Initializing Hub[ID: %d](host=%s, port=%d, username=%s, use_ssl=%s, installation_id=%s, model_name=%s, topic_prefix=%s, operation_mode=%s, device_type_exclude_filter=%s, update_frequency_seconds=%s, topic_log_info=%s)",
             self._instance_id,

--- a/victron_mqtt/metric.py
+++ b/victron_mqtt/metric.py
@@ -10,7 +10,14 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from .constants import MetricKind, MetricNature, MetricType, VictronEnum  # noqa: TC001
+from .constants import (
+    AUTO_UPDATE_INTERVAL_DEFAULT,
+    AUTO_UPDATE_INTERVALS,
+    MetricKind,
+    MetricNature,
+    MetricType,
+    VictronEnum,
+)
 from .data_classes import ParsedTopic, TopicDescriptor
 from .id_utils import replace_complex_ids
 
@@ -208,6 +215,15 @@ class Metric:
         return [e.id for e in self._descriptor.enum] if self._descriptor.enum else None
 
     @property
+    def update_interval_seconds(self) -> int | None:
+        """Effective update interval for this metric, resolved from the hub setting."""
+        frequency = self._hub._update_frequency_seconds
+        # The only string value Hub accepts is UPDATE_FREQUENCY_AUTO.
+        if isinstance(frequency, str):
+            return AUTO_UPDATE_INTERVALS.get(self._descriptor.metric_type, AUTO_UPDATE_INTERVAL_DEFAULT)
+        return frequency
+
+    @property
     def on_update(self) -> CallbackOnUpdate | None:
         """Returns the on_update callback."""
         return self._on_update
@@ -268,10 +284,11 @@ class Metric:
         if update_last_seen:
             self._last_seen = now
         should_notify = False
+        update_interval = self.update_interval_seconds
 
         # In case of zero update frequency, always consider changed when MQTT message is received
         # also if this is the first time the metric is being notified
-        if force or self._hub._update_frequency_seconds == 0 or self._last_notified == 0:
+        if force or update_interval == 0 or self._last_notified == 0:
             should_notify = True
             force = True
         elif value != self._value:
@@ -295,17 +312,17 @@ class Metric:
         # In case of non-zero update frequency, respect the update frequency limit only for numerical values
         if (
             not force
-            and self._hub._update_frequency_seconds is not None
+            and update_interval is not None
             and isinstance(value, float | int)
             and not isinstance(value, bool)  # bool is a subclass of int, but we only want real numeric sensor values.
         ):
             elapsed = now - self._last_notified
-            if elapsed < self._hub._update_frequency_seconds:
+            if elapsed < update_interval:
                 _LOGGER.debug(
                     "Update for %s skipped due to frequency limit (%.2fs < %ds)",
                     self.unique_id,
                     elapsed,
-                    self._hub._update_frequency_seconds,
+                    update_interval,
                 )
                 should_notify = False
             else:

--- a/victron_mqtt/metric.py
+++ b/victron_mqtt/metric.py
@@ -76,6 +76,14 @@ class Metric:
         self._last_seen: float = 0
         self._generic_short_id = self._descriptor.short_id
         self._generic_name = self._descriptor.generic_name
+        frequency = hub._update_frequency_seconds
+        if isinstance(frequency, str):
+            # The only string values Hub accepts are the auto profiles.
+            self._update_interval_seconds: int | None = AUTO_UPDATE_INTERVALS[frequency].get(
+                descriptor.metric_type, AUTO_UPDATE_INTERVAL_DEFAULT
+            )
+        else:
+            self._update_interval_seconds = frequency
 
         _LOGGER.debug("Metric %s initialized", repr(self))
 
@@ -216,12 +224,8 @@ class Metric:
 
     @property
     def update_interval_seconds(self) -> int | None:
-        """Effective update interval for this metric, resolved from the hub setting."""
-        frequency = self._hub._update_frequency_seconds
-        # The only string values Hub accepts are the auto profiles.
-        if isinstance(frequency, str):
-            return AUTO_UPDATE_INTERVALS[frequency].get(self._descriptor.metric_type, AUTO_UPDATE_INTERVAL_DEFAULT)
-        return frequency
+        """Effective update interval for this metric, resolved once from the hub setting."""
+        return self._update_interval_seconds
 
     @property
     def on_update(self) -> CallbackOnUpdate | None:
@@ -284,7 +288,7 @@ class Metric:
         if update_last_seen:
             self._last_seen = now
         should_notify = False
-        update_interval = self.update_interval_seconds
+        update_interval = self._update_interval_seconds
 
         # In case of zero update frequency, always consider changed when MQTT message is received
         # also if this is the first time the metric is being notified

--- a/victron_mqtt/metric.py
+++ b/victron_mqtt/metric.py
@@ -218,9 +218,9 @@ class Metric:
     def update_interval_seconds(self) -> int | None:
         """Effective update interval for this metric, resolved from the hub setting."""
         frequency = self._hub._update_frequency_seconds
-        # The only string value Hub accepts is UPDATE_FREQUENCY_AUTO.
+        # The only string values Hub accepts are the auto profiles.
         if isinstance(frequency, str):
-            return AUTO_UPDATE_INTERVALS.get(self._descriptor.metric_type, AUTO_UPDATE_INTERVAL_DEFAULT)
+            return AUTO_UPDATE_INTERVALS[frequency].get(self._descriptor.metric_type, AUTO_UPDATE_INTERVAL_DEFAULT)
         return frequency
 
     @property

--- a/victron_mqtt/testing/hub_helpers.py
+++ b/victron_mqtt/testing/hub_helpers.py
@@ -26,7 +26,7 @@ async def create_mocked_hub(
     installation_id: str | None = None,
     operation_mode: OperationMode = OperationMode.FULL,
     device_type_exclude_filter: list[DeviceType] | None = None,
-    update_frequency_seconds: int | Literal["auto"] | None = None,
+    update_frequency_seconds: int | Literal["auto", "auto_power_none"] | None = None,
     disable_keepalive_loop: bool = True,
 ) -> Hub:
     """Create and return a mocked Hub object for testing.
@@ -41,7 +41,8 @@ async def create_mocked_hub(
         operation_mode: The operation mode for the Hub (FULL, READ_ONLY, or EXPERIMENTAL).
         device_type_exclude_filter: Optional list of device types to exclude from processing.
         update_frequency_seconds: Optional update frequency for metrics in seconds,
-            or "auto" for per-metric-type intervals chosen by the library.
+            or an auto profile ("auto", "auto_power_none") for per-metric-type
+            intervals chosen by the library.
         disable_keepalive_loop: If True (default), disables the keepalive loop to prevent
             background tasks during testing. Set to False if you need to test keepalive behavior.
 

--- a/victron_mqtt/testing/hub_helpers.py
+++ b/victron_mqtt/testing/hub_helpers.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import logging
 from itertools import count
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock, patch
 
 from paho.mqtt.client import ConnectFlags
@@ -26,7 +26,7 @@ async def create_mocked_hub(
     installation_id: str | None = None,
     operation_mode: OperationMode = OperationMode.FULL,
     device_type_exclude_filter: list[DeviceType] | None = None,
-    update_frequency_seconds: int | None = None,
+    update_frequency_seconds: int | Literal["auto"] | None = None,
     disable_keepalive_loop: bool = True,
 ) -> Hub:
     """Create and return a mocked Hub object for testing.
@@ -40,7 +40,8 @@ async def create_mocked_hub(
             automatically set to "123" during connection.
         operation_mode: The operation mode for the Hub (FULL, READ_ONLY, or EXPERIMENTAL).
         device_type_exclude_filter: Optional list of device types to exclude from processing.
-        update_frequency_seconds: Optional update frequency for metrics in seconds.
+        update_frequency_seconds: Optional update frequency for metrics in seconds,
+            or "auto" for per-metric-type intervals chosen by the library.
         disable_keepalive_loop: If True (default), disables the keepalive loop to prevent
             background tasks during testing. Set to False if you need to test keepalive behavior.
 


### PR DESCRIPTION
## Context

The Home Assistant `victron_gx` integration currently hardcodes `update_frequency_seconds=30` when creating the `Hub`. Users are asking for a faster (or slower) entity refresh, but Home Assistant core convention is that integrations do not expose the update/polling interval as a configuration option: the [appropriate-polling](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/appropriate-polling/) quality-scale rule expects the integration to pick an interval that serves the majority of users, and users who need a different cadence are pointed to [a polling automation](https://www.home-assistant.io/common-tasks/general/#defining-a-custom-polling-interval) instead. So the integration — or better, the library, which has the domain knowledge — should pick an appropriate rhythm on its own.

A single global throttle cannot fit all metrics: grid/battery power can swing hundreds of watts within 30 s (users watching a live dashboard perceive this as lag), while battery SOC or temperature moves slowly and throttling adds nothing there. The library already knows each metric's semantics through `TopicDescriptor.metric_type`, so it can own this decision.

## What this PR does

Adds two auto profiles for `Hub(update_frequency_seconds=...)`. In auto mode each metric resolves its own update interval from its metric type:

| Profile | `POWER`, `APPARENT_POWER`, `CURRENT` | everything else |
|---|---|---|
| `"auto"` | 5 s | 30 s |
| `"auto_power_none"` | on every value change (no time limit) | 30 s |

The mappings live in `AUTO_UPDATE_INTERVALS` in `victron_mqtt/constants.py` (exported, with `AUTO_UPDATE_INTERVAL_DEFAULT` as the fallback), so tuning per-type intervals is a data change, not a consumer change. As before, throttling only applies to numeric values — enums, strings and booleans always propagate on change — and the existing keepalive re-publish still flushes skipped values.

Existing semantics are unchanged and remain available as explicit overrides: `None` (on change, still the default), `0` (every message), `N > 0` (global limit). Invalid strings are rejected with `ValueError` in the existing Hub validation block.

Also adds a public `Metric.update_interval_seconds` property exposing the resolved interval, test coverage for auto mode and validation, and README/docstring updates. `create_mocked_hub` accepts `"auto"` as well.

## Follow-up

If this is accepted, the HA integration can drop its hardcoded `UPDATE_INTERVAL_SECONDS = 30` and pass `update_frequency_seconds=UPDATE_FREQUENCY_AUTO`, inheriting the library-tuned behavior — no HA config option needed, which keeps it compliant with HA core policy. Happy to open that PR too.
