### PR TITLE
Add ssl_context parameter to Hub for TLS certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,17 @@ hub = victron_mqtt.Hub(
     operation_mode=OperationMode.FULL,  # FULL, READ_ONLY, or EXPERIMENTAL
     device_type_exclude_filter=None,    # Exclude specific device types
     update_frequency_seconds=None,      # Throttle update frequency
+    ssl_context=None,          # Custom SSL context for certificate verification
 )
 ```
+
+> **Security note:** with `use_ssl=True` and no `ssl_context`, the TLS connection does **not** verify the broker's certificate, because GX devices ship with self-signed certificates. To verify, pass a context with your CA loaded:
+>
+> ```python
+> import ssl
+> context = ssl.create_default_context(cafile="/path/to/venus-ca.crt")
+> hub = victron_mqtt.Hub("venus.local.", 8883, None, "password", True, ssl_context=context)
+> ```
 
 **Key properties:**
 - `hub.devices` — dict of all devices with visible metrics

--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -5,6 +5,7 @@ import asyncio
 import datetime
 import json
 import logging
+import ssl
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -3159,3 +3160,44 @@ async def test_dvcc_bol_off():
     sensor_metric = device.get_metric("system_dvcc_state")
     assert sensor_metric is not None
     assert sensor_metric.value == DVCCMode.OFF
+
+
+@pytest.mark.asyncio
+async def test_setup_tls_disabled():
+    """No TLS setup when use_ssl is False and no ssl_context is given."""
+    hub = Hub("localhost", 1883, None, None, use_ssl=False)
+    hub._client = MagicMock()
+    await hub._setup_tls()
+    hub._client.tls_set_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_tls_default_is_unverified():
+    """use_ssl without ssl_context keeps the legacy unverified context."""
+    hub = Hub("localhost", 1883, None, None, use_ssl=True)
+    hub._client = MagicMock()
+    await hub._setup_tls()
+    context = hub._client.tls_set_context.call_args[0][0]
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False
+
+
+@pytest.mark.asyncio
+async def test_setup_tls_custom_context_used_verbatim():
+    """A caller-provided ssl_context is passed through untouched."""
+    custom = ssl.create_default_context()
+    hub = Hub("localhost", 1883, None, None, use_ssl=True, ssl_context=custom)
+    hub._client = MagicMock()
+    await hub._setup_tls()
+    hub._client.tls_set_context.assert_called_once_with(custom)
+    assert custom.verify_mode == ssl.CERT_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_setup_tls_context_implies_tls():
+    """Providing ssl_context enables TLS even with use_ssl=False."""
+    custom = ssl.create_default_context()
+    hub = Hub("localhost", 1883, None, None, use_ssl=False, ssl_context=custom)
+    hub._client = MagicMock()
+    await hub._setup_tls()
+    hub._client.tls_set_context.assert_called_once_with(custom)

--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -3198,3 +3198,17 @@ def test_ssl_context_requires_use_ssl():
     custom = ssl.create_default_context()
     with pytest.raises(ValueError, match="ssl_context requires use_ssl=True"):
         Hub("localhost", 1883, None, None, use_ssl=False, ssl_context=custom)
+
+
+@pytest.mark.asyncio
+async def test_connect_sets_up_tls():
+    """connect() with use_ssl=True routes through _setup_tls and configures the client."""
+    hub = Hub("localhost", 8883, None, None, use_ssl=True)
+    hub._client = MagicMock()
+    with (
+        pytest.raises(CannotConnectError, match="Timeout"),
+        patch.object(hub, "_wait_for_connect", side_effect=CannotConnectError("Timeout waiting for first connection")),
+    ):
+        await hub.connect()
+    context = hub._client.tls_set_context.call_args[0][0]
+    assert context.verify_mode == ssl.CERT_NONE

--- a/tests/static_hub_test.py
+++ b/tests/static_hub_test.py
@@ -3193,11 +3193,8 @@ async def test_setup_tls_custom_context_used_verbatim():
     assert custom.verify_mode == ssl.CERT_REQUIRED
 
 
-@pytest.mark.asyncio
-async def test_setup_tls_context_implies_tls():
-    """Providing ssl_context enables TLS even with use_ssl=False."""
+def test_ssl_context_requires_use_ssl():
+    """Providing ssl_context with use_ssl=False is rejected."""
     custom = ssl.create_default_context()
-    hub = Hub("localhost", 1883, None, None, use_ssl=False, ssl_context=custom)
-    hub._client = MagicMock()
-    await hub._setup_tls()
-    hub._client.tls_set_context.assert_called_once_with(custom)
+    with pytest.raises(ValueError, match="ssl_context requires use_ssl=True"):
+        Hub("localhost", 1883, None, None, use_ssl=False, ssl_context=custom)

--- a/victron_mqtt/hub.py
+++ b/victron_mqtt/hub.py
@@ -96,6 +96,7 @@ class Hub:
         operation_mode: OperationMode = OperationMode.FULL,
         device_type_exclude_filter: list[DeviceType] | None = None,
         update_frequency_seconds: int | None = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         """
         Initialize a Hub instance for communicating with a Venus OS MQTT broker.
@@ -112,6 +113,14 @@ class Hub:
             Password for MQTT authentication, or None.
         use_ssl: bool
             If True, an SSL/TLS context will be configured when connecting.
+            WARNING: without `ssl_context`, certificates are NOT verified
+            (GX devices ship with self-signed certificates).
+        ssl_context: ssl.SSLContext | None
+            Custom SSL context for the TLS connection. Provide a context with
+            your CA loaded (e.g. `ssl.create_default_context(cafile=...)`) to
+            enable real certificate verification. When None and `use_ssl` is
+            True, a default context without certificate verification is used.
+            Providing a context enables TLS even if `use_ssl` is False.
         installation_id: str | None
             If provided, used to replace `{installation_id}` placeholders in topics.
             If None, the installation id will be discovered from the broker when
@@ -188,6 +197,7 @@ class Hub:
         self.password = password
         self.serial = serial
         self.use_ssl = use_ssl
+        self._ssl_context = ssl_context
         self.port = port
         self._expected_installation_id = installation_id
         self._topic_prefix = topic_prefix
@@ -346,12 +356,7 @@ class Hub:
             _LOGGER.info("Setting auth credentials for user: %s", self.username)
             self._client.username_pw_set(username, self.password)
 
-        if self.use_ssl:
-            _LOGGER.info("Setting up SSL context")
-            ssl_context = await asyncio.to_thread(ssl.create_default_context)
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.VerifyMode.CERT_NONE
-            self._client.tls_set_context(ssl_context)  # type: ignore[arg-type]
+        await self._setup_tls()
 
         self._client.on_connect = self._on_connect
         self._client.on_disconnect = self._on_disconnect
@@ -387,6 +392,26 @@ class Hub:
         self._setup_subscriptions()
         self._start_keep_alive_loop()
         _LOGGER.info("Connected. Installation ID: %s", self._installation_id)
+
+    async def _setup_tls(self) -> None:
+        """Configure TLS on the MQTT client if enabled.
+
+        Uses the caller-provided ssl_context when available; otherwise falls
+        back to an unverified context, as GX devices ship with self-signed
+        certificates.
+        """
+        if not self.use_ssl and self._ssl_context is None:
+            return
+        context = self._ssl_context
+        if context is None:
+            _LOGGER.info(
+                "TLS enabled without certificate verification (GX devices use self-signed certificates). "
+                "Pass ssl_context to Hub() to enable verification."
+            )
+            context = await asyncio.to_thread(ssl.create_default_context)
+            context.check_hostname = False
+            context.verify_mode = ssl.VerifyMode.CERT_NONE
+        self._client.tls_set_context(context)  # type: ignore[arg-type]
 
     def publish(self, topic_short_id: str, device_id: str, value: str | float | int | None) -> None:
         """Publish a message to the MQTT broker."""

--- a/victron_mqtt/hub.py
+++ b/victron_mqtt/hub.py
@@ -115,13 +115,6 @@ class Hub:
             If True, an SSL/TLS context will be configured when connecting.
             WARNING: without `ssl_context`, certificates are NOT verified
             (GX devices ship with self-signed certificates).
-        ssl_context: ssl.SSLContext | None
-            Custom SSL context for the TLS connection. Provide a context with
-            your CA loaded (e.g. `ssl.create_default_context(cafile=...)`) to
-            enable real certificate verification. When None and `use_ssl` is
-            True, a default context without certificate verification is used.
-            Only valid together with `use_ssl=True`; otherwise `ValueError`
-            is raised.
         installation_id: str | None
             If provided, used to replace `{installation_id}` placeholders in topics.
             If None, the installation id will be discovered from the broker when
@@ -144,6 +137,13 @@ class Hub:
             if None = Update only when source data change
             if 0 = Update as new mqtt data received
             if > 0 = Update no more than specified interval (in seconds)
+        ssl_context: ssl.SSLContext | None
+            Custom SSL context for the TLS connection. Provide a context with
+            your CA loaded (e.g. `ssl.create_default_context(cafile=...)`) to
+            enable real certificate verification. When None and `use_ssl` is
+            True, a default context without certificate verification is used.
+            Only valid together with `use_ssl=True`; otherwise `ValueError`
+            is raised.
 
         Behavior
         --------
@@ -405,6 +405,7 @@ class Hub:
         certificates.
         """
         if not self.use_ssl:
+            assert self._ssl_context is None, "ssl_context without use_ssl should have been rejected in __init__"
             return
         context = self._ssl_context
         if context is None:
@@ -415,6 +416,8 @@ class Hub:
             context = await asyncio.to_thread(ssl.create_default_context)
             context.check_hostname = False
             context.verify_mode = ssl.VerifyMode.CERT_NONE
+        else:
+            _LOGGER.info("TLS enabled with caller-provided SSL context")
         self._client.tls_set_context(context)  # type: ignore[arg-type]
 
     def publish(self, topic_short_id: str, device_id: str, value: str | float | int | None) -> None:

--- a/victron_mqtt/hub.py
+++ b/victron_mqtt/hub.py
@@ -120,7 +120,8 @@ class Hub:
             your CA loaded (e.g. `ssl.create_default_context(cafile=...)`) to
             enable real certificate verification. When None and `use_ssl` is
             True, a default context without certificate verification is used.
-            Providing a context enables TLS even if `use_ssl` is False.
+            Only valid together with `use_ssl=True`; otherwise `ValueError`
+            is raised.
         installation_id: str | None
             If provided, used to replace `{installation_id}` placeholders in topics.
             If None, the installation id will be discovered from the broker when
@@ -157,7 +158,8 @@ class Hub:
         Raises
         ------
         ValueError
-            If `host` is empty or `port` is out of the valid range.
+            If `host` is empty, `port` is out of the valid range, or
+            `ssl_context` is provided without `use_ssl=True`.
         TypeError
             If an argument has an incorrect type.
         """
@@ -176,6 +178,8 @@ class Hub:
             raise ValueError("host must be a non-empty string")
         if not 0 < port < 65536:
             raise ValueError("port must be an integer between 1 and 65535")
+        if ssl_context is not None and not use_ssl:
+            raise ValueError("ssl_context requires use_ssl=True")
         _LOGGER.info(
             "Initializing Hub[ID: %d](host=%s, port=%d, username=%s, use_ssl=%s, installation_id=%s, model_name=%s, topic_prefix=%s, operation_mode=%s, device_type_exclude_filter=%s, update_frequency_seconds=%s, topic_log_info=%s)",
             self._instance_id,
@@ -400,7 +404,7 @@ class Hub:
         back to an unverified context, as GX devices ship with self-signed
         certificates.
         """
-        if not self.use_ssl and self._ssl_context is None:
+        if not self.use_ssl:
             return
         context = self._ssl_context
         if context is None:


### PR DESCRIPTION
Currently TLS connections always disable certificate verification (`check_hostname=False`, `CERT_NONE`) with no way to opt in to real verification.

This PR adds an optional `ssl_context` parameter to `Hub()` (at the end of the signature, fully backward compatible):

- If provided, the context is used as-is — e.g. with the GX device's CA loaded — giving real certificate verification. It is only valid together with `use_ssl=True`; passing it with `use_ssl=False` raises `ValueError`.
- If not provided, behavior is unchanged (unverified TLS, which remains the right default since GX devices ship with self-signed certificates), but the unverified mode is now logged at connect time and documented in the `Hub` docstring and a README security note.

TLS setup logic is factored into `Hub._setup_tls()`, with 4 new tests covering both modes.

**Note on API surface**: since this adds a public parameter to `Hub()`, I'd especially like your opinion on the naming/shape before merging.
