### PR TITLE
Use 1 W steps for ESS max feed-in power

### DIFF
--- a/tests/static_test.py
+++ b/tests/static_test.py
@@ -45,6 +45,12 @@ def test_no_duplicate_device_type_and_name():
         pytest.fail("\n".join(errors))
 
 
+def test_ess_max_feed_in_power_uses_single_watt_steps():
+    descriptor = next(topic for topic in topics if topic.short_id == "system_ess_max_feed_in_power")
+
+    assert descriptor.step == 1
+
+
 def test_naming_unit_consistency():
     errors = []
     for descriptor in topics:

--- a/victron_mqtt/_victron_topics.py
+++ b/victron_mqtt/_victron_topics.py
@@ -2407,7 +2407,7 @@ topics: list[TopicDescriptor] = [
         min_max_range=RangeType.DYNAMIC,
         min=-1,
         max=1000000,
-        step=100,
+        step=1,
     ),
     TopicDescriptor(
         topic="N/{installation_id}/settings/{device_id}/Settings/CGwacs/OvervoltageFeedIn",


### PR DESCRIPTION
Closes #118

`MaxFeedInPower` currently advertises 100 W increments even though Venus OS accepts integer-watt values. This changes the descriptor step to 1 W and adds a static regression test; all 29 static topic tests pass.
