### PR TITLE
Internalize aiohttp session in request_pairing_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,6 @@ GX devices running Venus OS v3.80 or newer support token-based MQTT authenticati
 
 ```python
 import asyncio
-import ssl
-
-import aiohttp
 
 from victron_mqtt import Hub, PairingError, request_pairing_token
 
@@ -263,17 +260,11 @@ from victron_mqtt import Hub, PairingError, request_pairing_token
 async def main():
     host = "venus.local."
 
-    # Disable certificate verification for self-signed GX certificates
-    ssl_ctx = ssl.create_default_context()
-    ssl_ctx.check_hostname = False
-    ssl_ctx.verify_mode = ssl.CERT_NONE
-
-    async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=ssl_ctx)) as session:
-        try:
-            credentials = await request_pairing_token(host, "ab4c9ab6b98a", session)
-        except PairingError as exc:
-            print(f"Pairing failed: {exc}")
-            return
+    try:
+        credentials = await request_pairing_token(host, "ab4c9ab6b98a")
+    except PairingError as exc:
+        print(f"Pairing failed: {exc}")
+        return
 
     # credentials is a PairingToken(token_name=..., password=...)
     print(f"Username: {credentials.token_name}")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,7 +1,7 @@
 """Tests for the GX device MQTT token pairing function."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -21,6 +21,14 @@ def _mock_session(*, status: int = 200, json_data: dict[str, Any] | None = None,
     return session
 
 
+def _patch_client_session(session: MagicMock):
+    """Patch aiohttp.ClientSession to return *session* as an async context manager."""
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return patch("victron_mqtt.pairing.aiohttp.ClientSession", return_value=ctx)
+
+
 # -- successful pairing ------------------------------------------------
 
 
@@ -33,7 +41,8 @@ async def test_successful_pairing_returns_credentials():
     }
     session = _mock_session(status=200, json_data=payload)
 
-    result = await request_pairing_token("192.168.1.10", "ab4c9ab6b98a", session)
+    with _patch_client_session(session):
+        result = await request_pairing_token("192.168.1.10", "ab4c9ab6b98a")
 
     assert isinstance(result, PairingToken)
     assert result.token_name == "token/homeassistant/ab4c9ab6b98a"
@@ -48,7 +57,8 @@ async def test_successful_pairing_posts_to_correct_url():
         "password": "Rn5tGx8WqJ3vKm7ePd2sYfLb6HcAoU9Z"
     })
 
-    await request_pairing_token("venus.local", "c7e2f03d81a5", session)
+    with _patch_client_session(session):
+        await request_pairing_token("venus.local", "c7e2f03d81a5")
 
     session.post.assert_called_once_with(
         "https://venus.local/auth/generate-token/",
@@ -64,7 +74,8 @@ async def test_successful_pairing_with_custom_role():
         "password": "Vc3nFx7WqJ9tKm2ePd5sYgLb8HcAoU6Z"
     })
 
-    await request_pairing_token("10.0.0.1", "d9f1a47e52b3", session, role="custom_role")
+    with _patch_client_session(session):
+        await request_pairing_token("10.0.0.1", "d9f1a47e52b3", role="custom_role")
 
     session.post.assert_called_once_with(
         "https://10.0.0.1/auth/generate-token/",
@@ -84,7 +95,8 @@ async def test_successful_pairing_extended_response():
     }
     session = _mock_session(status=200, json_data=payload)
 
-    result = await request_pairing_token("192.168.1.10", "e8b3d2f71a06", session)
+    with _patch_client_session(session):
+        result = await request_pairing_token("192.168.1.10", "e8b3d2f71a06")
 
     assert isinstance(result, PairingToken)
     assert result.token_name == "token/homeassistant/e8b3d2f71a06"
@@ -97,12 +109,8 @@ async def test_successful_pairing_extended_response():
 @pytest.mark.asyncio
 async def test_non_alphanumeric_device_id_raises_value_error():
     """A device_id with non-alphanumeric characters is rejected before any HTTP call."""
-    session = _mock_session(status=200, json_data={"token_name": "t", "password": "p"})
-
     with pytest.raises(ValueError, match="alphanumeric"):
-        await request_pairing_token("192.168.1.10", "bad-id!", session)
-
-    session.post.assert_not_called()
+        await request_pairing_token("192.168.1.10", "bad-id!")
 
 
 @pytest.mark.asyncio
@@ -110,8 +118,8 @@ async def test_403_raises_pairing_error():
     """A 403 (pairing mode not enabled) raises PairingError."""
     session = _mock_session(status=403, text="Pairing mode not enabled")
 
-    with pytest.raises(PairingError, match="HTTP 403"):
-        await request_pairing_token("192.168.1.10", "abc", session)
+    with _patch_client_session(session), pytest.raises(PairingError, match="HTTP 403"):
+        await request_pairing_token("192.168.1.10", "abc")
 
 
 @pytest.mark.asyncio
@@ -119,8 +127,8 @@ async def test_500_raises_pairing_error():
     """A server error raises PairingError with status and body."""
     session = _mock_session(status=500, text="Internal Server Error")
 
-    with pytest.raises(PairingError, match=r"HTTP 500.*Internal Server Error"):
-        await request_pairing_token("192.168.1.10", "abc", session)
+    with _patch_client_session(session), pytest.raises(PairingError, match=r"HTTP 500.*Internal Server Error"):
+        await request_pairing_token("192.168.1.10", "abc")
 
 
 @pytest.mark.asyncio
@@ -128,8 +136,8 @@ async def test_401_raises_pairing_error():
     """An unauthorized response raises PairingError."""
     session = _mock_session(status=401, text="Unauthorized")
 
-    with pytest.raises(PairingError, match="HTTP 401"):
-        await request_pairing_token("192.168.1.10", "abc", session)
+    with _patch_client_session(session), pytest.raises(PairingError, match="HTTP 401"):
+        await request_pairing_token("192.168.1.10", "abc")
 
 
 @pytest.mark.asyncio
@@ -140,5 +148,5 @@ async def test_network_error_propagates():
         connection_key=MagicMock(), os_error=OSError("Connection refused"),
     ))
 
-    with pytest.raises(aiohttp.ClientError):
-        await request_pairing_token("192.168.1.10", "abc", session)
+    with _patch_client_session(session), pytest.raises(aiohttp.ClientError):
+        await request_pairing_token("192.168.1.10", "abc")

--- a/victron_mqtt/pairing.py
+++ b/victron_mqtt/pairing.py
@@ -24,7 +24,6 @@ class PairingToken:
 async def request_pairing_token(
     host: str,
     device_id: str,
-    session: aiohttp.ClientSession,
     *,
     role: str = "homeassistant",
 ) -> PairingToken:
@@ -38,7 +37,6 @@ async def request_pairing_token(
     Args:
         host: Hostname or IP of the GX device.
         device_id: Alphanumeric identifier for this client (e.g. installation_id).
-        session: An aiohttp ClientSession (caller controls SSL verification).
         role: Role name sent to the GX device (default: "homeassistant").
 
     Returns:
@@ -52,6 +50,20 @@ async def request_pairing_token(
     """
     if not device_id.isalnum():
         raise ValueError(f"device_id must be alphanumeric, got: {device_id!r}")
+
+    async with aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(ssl=False),
+    ) as session:
+        return await _do_pairing_request(host, device_id, session, role=role)
+
+
+async def _do_pairing_request(
+    host: str,
+    device_id: str,
+    session: aiohttp.ClientSession,
+    *,
+    role: str,
+) -> PairingToken:
     url = f"https://{host}/auth/generate-token/"
     resp = await session.post(
         url,


### PR DESCRIPTION
Move `ClientSession` creation into `request_pairing_token` so callers no longer need to manage SSL configuration. The session parameter is replaced by an internal TCPConnector(ssl=False) session, and the HTTP logic is extracted into a private `_do_pairing_request` helper.