### PR TITLE
Accept optional aiohttp session in request_pairing_token

### DIFF
--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -150,3 +150,26 @@ async def test_network_error_propagates():
 
     with _patch_client_session(session), pytest.raises(aiohttp.ClientError):
         await request_pairing_token("192.168.1.10", "abc")
+
+
+# -- injected session --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_injected_session_is_used_directly():
+    """When a session is passed, it is used without creating a new one."""
+    payload = {
+        "token_name": "token/homeassistant/f1a2b3c4d5e6",
+        "password": "Qw8rTx3YjN9vBm2sZdKe6UfHc7gAoP1L",
+    }
+    session = _mock_session(status=200, json_data=payload)
+
+    with patch("victron_mqtt.pairing.aiohttp.ClientSession") as mock_cls:
+        result = await request_pairing_token(
+            "192.168.1.10", "f1a2b3c4d5e6", session=session
+        )
+
+    mock_cls.assert_not_called()
+    assert isinstance(result, PairingToken)
+    assert result.token_name == "token/homeassistant/f1a2b3c4d5e6"
+    session.post.assert_called_once()

--- a/victron_mqtt/pairing.py
+++ b/victron_mqtt/pairing.py
@@ -26,6 +26,7 @@ async def request_pairing_token(
     device_id: str,
     *,
     role: str = "homeassistant",
+    session: aiohttp.ClientSession | None = None,
 ) -> PairingToken:
     """Request MQTT pairing credentials from a GX device via HTTPS.
 
@@ -38,6 +39,8 @@ async def request_pairing_token(
         host: Hostname or IP of the GX device.
         device_id: Alphanumeric identifier for this client (e.g. installation_id).
         role: Role name sent to the GX device (default: "homeassistant").
+        session: Optional aiohttp session to reuse. When *None* a temporary
+            session is created and closed automatically.
 
     Returns:
         A PairingToken with token_name and password fields.
@@ -51,10 +54,13 @@ async def request_pairing_token(
     if not device_id.isalnum():
         raise ValueError(f"device_id must be alphanumeric, got: {device_id!r}")
 
+    if session is not None:
+        return await _do_pairing_request(host, device_id, session, role=role)
+
     async with aiohttp.ClientSession(
         connector=aiohttp.TCPConnector(ssl=False),
-    ) as session:
-        return await _do_pairing_request(host, device_id, session, role=role)
+    ) as new_session:
+        return await _do_pairing_request(host, device_id, new_session, role=role)
 
 
 async def _do_pairing_request(


### PR DESCRIPTION
Allow callers to inject a managed aiohttp.ClientSession (e.g. async_get_clientsession in Home Assistant) instead of always creating an internal one. When no session is passed, behaviour is unchanged.